### PR TITLE
Add RSS Feed

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -3,3 +3,4 @@ plugins:
 title: Awesome Badger
 description: Assorted thinking (mostly) about technology written by the Badgers.
 author: Red Badger
+lang: en

--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,5 @@
+plugins:
+  - jekyll-feed
+title: Awesome Badger
+description: Assorted thinking (mostly) about technology written by the Badgers.
+author: Red Badger

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html lang="{{ site.lang | default: "en-US" }}">
+<head>
+    <meta charset="UTF-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link rel="alternate" type="application/atom+xml" title="Awesome Badger" href="/feed.xml">
+
+    {% seo %}
+    <link rel="stylesheet" href="{{ "/assets/css/style.css?v=" | append: site.github.build_revision | relative_url }}">
+</head>
+<body>
+<div class="container-lg px-3 my-5 markdown-body">
+    {% if site.title and site.title != page.title %}
+    <h1><a href="{{ "/" | absolute_url }}">{{ site.title }}</a></h1>
+    {% endif %}
+
+    {{ content }}
+
+    {% if site.github.private != true and site.github.license %}
+    <div class="footer border-top border-gray-light mt-5 pt-3 text-right text-gray">
+        This site is open source. {% github_edit_link "Improve this page" %}.
+    </div>
+    {% endif %}
+
+
+    <div class="footer border-top border-gray-light mt-5 pt-3 text-right text-gray">
+        <a class="btn btn-rss" href="/feed.xml" target="_blank">RSS</a>
+    </div>
+
+</div>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/anchor-js/4.1.0/anchor.min.js" integrity="sha256-lZaRhKri35AyJSypXXs4o6OPFTbTmUoltBbDCbdzegg=" crossorigin="anonymous"></script>
+<script>anchors.add();</script>
+{% if site.google_analytics %}
+<script>
+  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+  })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+  ga('create', '{{ site.google_analytics }}', 'auto');
+  ga('send', 'pageview');
+</script>
+{% endif %}
+</body>
+</html>


### PR DESCRIPTION
Answering the request from https://twitter.com/dmy365/status/1349994421799034882

Followed tutorial here:
- https://dzhavat.github.io/2020/01/19/adding-an-rss-feed-to-github-pages.html

I've learned that the default GH pages theme is primer
https://github.com/pages-themes/primer

This is where I extracted the `_layouts/default.html` file

It looks like adding google analytics is now just updating `_config.yml`