### PR TITLE
Correct pathname to README.md files

### DIFF
--- a/_posts/2025-01-30-sha256-extended.md
+++ b/_posts/2025-01-30-sha256-extended.md
@@ -32,18 +32,18 @@ The purpose of this update therefore is to significantly reduce the degree of co
 
 # Overview of Steps
 
-1. [Getting Started](/chriswhealy/sha256-extended/00-getting-started/README.md)
-2. [Start WASI](/chriswhealy/sha256-extended/10-start-wasi/README.md)
-3. [Import WASI Functions into WebAssembly](/chriswhealy/sha256-extended/20-import-wasi/README.md)
-4. [Count the Command Line Arguments](/chriswhealy/sha256-extended/30-count-cmd-line-args/README.md)
-5. [Extract the filename from the command line arguments](/chriswhealy/sha256-extended/40-parse-cmd-line-args/README.md)
-6. [Open the file](/chriswhealy/sha256-extended/50-open-file/README.md)
-7. [Read the File Size](/chriswhealy/sha256-extended/60-read-file-size/README.md)
-8. [Do We Have Enough Memory?](/chriswhealy/sha256-extended/70-grow-memory/README.md)
-9. [Read the file into memory](/chriswhealy/sha256-extended/80-read-file/README.md)
-10. [Close the file](/chriswhealy/sha256-extended/90-close-file/README.md)
+1. [Getting Started](/chriswhealy/sha256-extended/00-getting-started/)
+2. [Start WASI](/chriswhealy/sha256-extended/10-start-wasi/)
+3. [Import WASI Functions into WebAssembly](/chriswhealy/sha256-extended/20-import-wasi/)
+4. [Count the Command Line Arguments](/chriswhealy/sha256-extended/30-count-cmd-line-args/)
+5. [Extract the filename from the command line arguments](/chriswhealy/sha256-extended/40-parse-cmd-line-args/)
+6. [Open the file](/chriswhealy/sha256-extended/50-open-file/)
+7. [Read the File Size](/chriswhealy/sha256-extended/60-read-file-size/)
+8. [Do We Have Enough Memory?](/chriswhealy/sha256-extended/70-grow-memory/)
+9. [Read the file into memory](/chriswhealy/sha256-extended/80-read-file/)
+10. [Close the file](/chriswhealy/sha256-extended/90-close-file/)
 
 # Extras
 
-1. [WebAssembly Coding Tips and Tricks](/chriswhealy/sha256-extended/wat_tips_and_tricks/README.md)
-2. [Debugging WASM](/chriswhealy/sha256-extended/debugging_wasm/README.md)
+1. [WebAssembly Coding Tips and Tricks](/chriswhealy/sha256-extended/wat_tips_and_tricks/)
+2. [Debugging WASM](/chriswhealy/sha256-extended/debugging_wasm/)


### PR DESCRIPTION
The README.md files were being displayed as plain text instead of being formatted.
This PR should correct that
:-)